### PR TITLE
Improve dataset chunking and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# digital-me
+# Digital Me Dataset Tools
+
+This repository contains utilities to extract text from PDF and EPUB books and
+prepare a dataset for OpenAI fine-tuning.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Create a YAML configuration file specifying the author, output dataset file, and
+books with page ranges to include. You can also control how the text is split
+into chunks using the optional `chunk_size` and `overlap` settings. A report of
+the planned splits is written before the dataset is generated. An example
+configuration is provided in `example_config.yaml`.
+
+Run the dataset generation script:
+
+```bash
+python generate_dataset.py path/to/config.yaml
+```
+
+The script shows progress for each book and the pages processed using `tqdm` and
+leverages all available CPU cores to convert multiple books in parallel. Each
+book is split into overlapping chunks, and a report describing the split is
+saved alongside the dataset.
+
+Each entry in the output `.jsonl` will contain a `prompt` instructing the model
+to write in the style of the given author and a `completion` holding the text
+extracted from the book pages.

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,0 +1,12 @@
+author: "Author Name"
+output_file: "dataset.jsonl"
+chunk_size: 1024
+overlap: 0.25
+report_file: "split_report.json"
+books:
+  - path: "path/to/book1.pdf"
+    start_page: 1
+    end_page: 100
+  - path: "path/to/book2.epub"
+    start_page: 5
+    end_page: 50

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -1,0 +1,123 @@
+import os
+import json
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import yaml
+from PyPDF2 import PdfReader
+from ebooklib import epub
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+
+def extract_pdf_text(path, start, end, position=0):
+    reader = PdfReader(path)
+    num_pages = len(reader.pages)
+    extracted = []
+    start = max(start, 1)
+    end = min(end, num_pages)
+    page_range = range(start - 1, end)
+    for i in tqdm(page_range, desc=os.path.basename(path), position=position, leave=False):
+        page = reader.pages[i]
+        text = page.extract_text() or ""
+        extracted.append(text)
+    return extracted
+
+
+def extract_epub_text(path, start, end, position=0, words_per_page=700):
+    book = epub.read_epub(path)
+    texts = []
+    for item in book.get_items():
+        if item.get_type() == epub.EpubHtml:
+            soup = BeautifulSoup(item.get_content(), "html.parser")
+            texts.append(soup.get_text())
+    words = " ".join(texts).split()
+    pages = [" ".join(words[i:i + words_per_page]) for i in range(0, len(words), words_per_page)]
+    start = max(start, 1)
+    end = min(end, len(pages))
+    extracted = []
+    page_range = range(start - 1, end)
+    for i in tqdm(page_range, desc=os.path.basename(path), position=position, leave=False):
+        extracted.append(pages[i])
+    return extracted
+
+
+def main(config_path):
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    author = config.get("author", "")
+    output = config.get("output_file", "dataset.jsonl")
+    books = config.get("books", [])
+    chunk_size = int(config.get("chunk_size", 1024))
+    overlap = float(config.get("overlap", 0.25))
+    report_file = config.get("report_file", os.path.splitext(output)[0] + "_report.json")
+
+    prompt = f"Write a passage in the style of {author}."
+
+    def process_book(book, position):
+        path = book["path"]
+        start = int(book.get("start_page", 1))
+        end = int(book.get("end_page", 1))
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Book not found: {path}")
+
+        ext = os.path.splitext(path)[1].lower()
+        if ext == ".pdf":
+            pages = extract_pdf_text(path, start, end, position=position)
+        elif ext == ".epub":
+            pages = extract_epub_text(path, start, end, position=position)
+        else:
+            raise ValueError(f"Unsupported file type: {path}")
+
+        text = "\n".join(pages)
+        words = text.split()
+
+        overlap_words = max(0, min(int(chunk_size * overlap), chunk_size - 1))
+        step = max(1, chunk_size - overlap_words)
+
+        records = []
+        splits = []
+        for idx in range(0, len(words), step):
+            chunk_words = words[idx:idx + chunk_size]
+            if not chunk_words:
+                break
+            record = {"prompt": prompt, "completion": " ".join(chunk_words).strip()}
+            records.append(record)
+            splits.append({"chunk_index": len(splits) + 1, "start_word": idx + 1, "end_word": idx + len(chunk_words)})
+
+        report_entry = {
+            "book": path,
+            "start_page": start,
+            "end_page": end,
+            "total_words": len(words),
+            "chunk_size": chunk_size,
+            "overlap": overlap,
+            "num_chunks": len(splits),
+            "chunks": splits,
+        }
+
+        return records, report_entry
+
+    all_records = []
+    report = []
+    with ThreadPoolExecutor(max_workers=os.cpu_count() or 1) as executor:
+        futures = [executor.submit(process_book, book, idx + 1) for idx, book in enumerate(books)]
+        for f in tqdm(as_completed(futures), total=len(futures), desc="Books"):
+            records, rep = f.result()
+            all_records.extend(records)
+            report.append(rep)
+
+    with open(report_file, "w", encoding="utf-8") as rep_f:
+        json.dump(report, rep_f, ensure_ascii=False, indent=2)
+
+    with open(output, "w", encoding="utf-8") as out_f:
+        for record in all_records:
+            json_line = json.dumps(record, ensure_ascii=False)
+            out_f.write(json_line + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create fine-tuning dataset from books.")
+    parser.add_argument("config", help="Path to YAML config file")
+    args = parser.parse_args()
+    main(args.config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PyPDF2
+ebooklib
+beautifulsoup4
+PyYAML
+tqdm


### PR DESCRIPTION
## Summary
- support configurable chunk size and overlap when building the dataset
- generate a JSON report describing the split before writing dataset
- document new settings in README
- update example config with chunk options

## Testing
- `python -m py_compile generate_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_685e0d50be1c8323b2aacf4f29911a37